### PR TITLE
[fix] remove a typo in Vote.choice choices abstent/absent

### DIFF
--- a/apps/votes/models.py
+++ b/apps/votes/models.py
@@ -67,7 +67,7 @@ class Recommendation(models.Model):
         ordering = ['datetime']
 
 class Vote(models.Model):
-    choice = models.CharField(max_length=15, choices=((u'for', u'for'), (u'against', u'against'), (u'abstention', u'abstention'), (u'abstent', u'abstent')))
+    choice = models.CharField(max_length=15, choices=((u'for', u'for'), (u'against', u'against'), (u'abstention', u'abstention'), (u'absent', u'absent')))
     name = models.CharField(max_length=127)
     recommendation = models.ForeignKey(Recommendation)
     representative = models.ForeignKey(Representative, null=True)


### PR DESCRIPTION
As requested an independent pull request
